### PR TITLE
onboard OSS fixes and Django upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/_build
 .cache
 .tox
 .python-version
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ env:
     - TOX_ENV=py34-dj110
     - TOX_ENV=py34-dj111
 
-python:
-  - "2.7"
-  - "3.4"
-
 install:
   - pip install tox coverage coveralls
 

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,14 @@ Twitter Bootstrap for Django Form.
 
 A simple Django template tag to work with `Bootstrap <http://getbootstrap.com/>`_
 
+Installation
+======
+
+Install django-bootstrap-form with pip
+
+.. code-block:: sh
+
+    $ pip install django-bootstrap-form
 
 Usage
 ======

--- a/bootstrapform/meta.py
+++ b/bootstrapform/meta.py
@@ -1,5 +1,5 @@
 from distutils.version import StrictVersion
 
 
-VERSION = StrictVersion('3.2.1')
+VERSION = StrictVersion('3.3')
 

--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -78,7 +78,8 @@ def render(element, markup_classes):
             template = get_template("bootstrapform/form.html")
             context = {'form': element, 'classes': markup_classes}
 
-    if django.VERSION[0] * 1000 + django.VERSION[1] < 1008:
+
+    if django_version < (1, 11):
         context = Context(context)
 
     if django_version >= (1, 8):

--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -77,8 +77,8 @@ def render(element, markup_classes):
             template = get_template("bootstrapform/form.html")
             context = Context({'form': element, 'classes': markup_classes})
 
-        if django_version >= (1, 8):
-            context = context.flatten()
+    if django_version >= (1, 8):
+        context = context.flatten()
 
     return template.render(context)
 

--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -1,3 +1,4 @@
+import django
 from django import forms
 from django.template import Context
 from django.template.loader import get_template
@@ -60,7 +61,7 @@ def render(element, markup_classes):
     if element_type == 'boundfield':
         add_input_classes(element)
         template = get_template("bootstrapform/field.html")
-        context = Context({'field': element, 'classes': markup_classes, 'form': element.form})
+        context = {'field': element, 'classes': markup_classes, 'form': element.form}
     else:
         has_management = getattr(element, 'management_form', None)
         if has_management:
@@ -69,13 +70,16 @@ def render(element, markup_classes):
                     add_input_classes(field)
 
             template = get_template("bootstrapform/formset.html")
-            context = Context({'formset': element, 'classes': markup_classes})
+            context = {'formset': element, 'classes': markup_classes}
         else:
             for field in element.visible_fields():
                 add_input_classes(field)
 
             template = get_template("bootstrapform/form.html")
-            context = Context({'form': element, 'classes': markup_classes})
+            context = {'form': element, 'classes': markup_classes}
+
+    if django.VERSION[0] * 1000 + django.VERSION[1] < 1008:
+        context = Context(context)
 
     return template.render(context)
 

--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -79,11 +79,8 @@ def render(element, markup_classes):
             context = {'form': element, 'classes': markup_classes}
 
 
-    if django_version < (1, 11):
+    if django_version < (1, 8):
         context = Context(context)
-
-    if django_version >= (1, 8):
-        context = context.flatten()
 
     return template.render(context)
 

--- a/bootstrapform/tests.py
+++ b/bootstrapform/tests.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from django.template import Template, Context
 from django import forms
 
+from .templatetags import bootstrap
 
 TEST_DIR = os.path.abspath(os.path.join(__file__, '..'))
 
@@ -23,15 +24,15 @@ except:
     pass
 
 class ExampleForm(forms.Form):
-    char_field = forms.CharField()
-    choice_field = forms.ChoiceField(choices=CHOICES)
-    radio_choice = forms.ChoiceField(choices=CHOICES, widget=forms.RadioSelect)
-    multiple_choice = forms.MultipleChoiceField(choices=CHOICES)
-    multiple_checkbox = forms.MultipleChoiceField(choices=CHOICES, widget=forms.CheckboxSelectMultiple)
-    file_fied = forms.FileField()
-    password_field = forms.CharField(widget=forms.PasswordInput)
-    textarea = forms.CharField(widget=forms.Textarea)
-    boolean_field = forms.BooleanField()
+    char_field = forms.CharField(required=False)
+    choice_field = forms.ChoiceField(choices=CHOICES, required=False)
+    radio_choice = forms.ChoiceField(choices=CHOICES, widget=forms.RadioSelect, required=False)
+    multiple_choice = forms.MultipleChoiceField(choices=CHOICES, required=False)
+    multiple_checkbox = forms.MultipleChoiceField(choices=CHOICES, widget=forms.CheckboxSelectMultiple, required=False)
+    file_fied = forms.FileField(required=False)
+    password_field = forms.CharField(widget=forms.PasswordInput, required=False)
+    textarea = forms.CharField(widget=forms.Textarea, required=False)
+    boolean_field = forms.BooleanField(required=False)
 
 
 class BootstrapTemplateTagTests(TestCase):
@@ -73,3 +74,9 @@ class BootstrapTemplateTagTests(TestCase):
             content = f.read()
 
         self.assertHTMLEqual(html, content)
+
+    def test_bound_field(self):
+        form = ExampleForm(data={'char_field': 'asdf'})
+
+        self.assertTrue(form.is_bound)
+        rendered_template = bootstrap.bootstrap(form['char_field'])

--- a/runtests.py
+++ b/runtests.py
@@ -34,6 +34,12 @@ settings.configure(
     SITE_ID=1,
     DEBUG=False,
     ROOT_URLCONF='',
+    TEMPLATES = [  # For >= Django 1.10
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'APP_DIRS': True,
+        },
+    ]
 )
 
 

--- a/runtests.py
+++ b/runtests.py
@@ -35,10 +35,7 @@ settings.configure(
     DEBUG=False,
     ROOT_URLCONF='',
     TEMPLATES = [  # For >= Django 1.10
-        {
-            'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'APP_DIRS': True,
-        },
+        {'BACKEND': 'django.template.backends.django.DjangoTemplates', 'APP_DIRS': True},
     ]
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34}-dj{15,16,17,18,19}
+envlist = {py27,py34}-dj{15,16,17,18,19,110}
 skipsdist=True
 
 
@@ -14,6 +14,7 @@ deps =
     dj17: django>=1.7,<1.8
     dj18: django>=1.8,<1.9
     dj19: django>=1.9,<1.10
+    dj110: django>=1.10,<1.11
 commands = python setup.py test
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34}-dj{15,16,17,18,19,110}
+envlist = {py27,py34}-dj{15,16,17,18,19,110,111}
 skipsdist=True
 
 
@@ -15,6 +15,7 @@ deps =
     dj18: django>=1.8,<1.9
     dj19: django>=1.9,<1.10
     dj110: django>=1.10,<1.11
+    dj111: django>=1.10,<1.11
 commands = python setup.py test
 
 


### PR DESCRIPTION
The original OSS already has a couple of fixes and uses the latest Django version.
In order to avoid work duplication, the upstream changes are merged to this repository.
This will help the port to Django 1.11.

Note:
This includes a merge commit: it should help to merge back from `tzangms/django-bootstrap-form` later on as it preserves the commit IDs.